### PR TITLE
Support Minecart Compatibility Layer and newer MinecraftForge.

### DIFF
--- a/src/com/bergerkiller/bukkit/tc/NativeMinecartMember.java
+++ b/src/com/bergerkiller/bukkit/tc/NativeMinecartMember.java
@@ -1044,4 +1044,7 @@ public class NativeMinecartMember extends EntityMinecart {
 
 	}
 
+	public boolean canBeRidden() { return this.type == 0; }
+	public boolean isStorageCart() { return this.type == 1; }
+	public boolean isPoweredCart() { return this.type == 2; }
 }


### PR DESCRIPTION
These 3 simple lines allow carts to be used on a modded Bukkit version with MCL. Without them carts cannot be boarded or opened.

They will still not allow TrainCarts to work with minecart-based mods, such as RailCraft, but that's an entirely different layer of complexity.
